### PR TITLE
Convert step files to Raspberry Flavoured Markdown

### DIFF
--- a/en/step_1.md
+++ b/en/step_1.md
@@ -1,8 +1,8 @@
-<h2 class="c-project-heading--task">Add a turtle</h2>
+## Add a turtle
 
 Create your first racing turtle and get it ready at the starting line.
 
-<h2 class="c-project-heading--explainer">Say hello to Ada! 🐢</h2>
+**Say hello to Ada! 🐢**
 
 Start by adding one turtle to the screen.
 
@@ -10,46 +10,26 @@ You can name the turtle anything you like. Here, it is called `ada`.
 
 This turtle gets a colour and shape, then moves to its starting position on the track.
 
-
-<div class="c-project-code">
---- code ---
----
-language: python
-filename: main.py
-line_numbers: true
-line_number_start: 4
-line_highlights: 4-9
----
+```python filename="main.py" line_numbers="true" line_number_start="4" line_highlights="4-9"
 ada = Turtle()
 ada.color('red')
 ada.shape('turtle')
 ada.penup()
 ada.goto(-160, 100)
 ada.pendown()
---- /code ---
-</div>
+```
 
-<div class="c-project-output">
-![one red turtle at the left side of the screen](images/step_1.png)
-</div>
+> [!TIP]
+>
+> - You can change the colour of the turtle to anything you like.
+> - The `goto` sets the `x` and `y` position of the turtle on the screen.
 
-### Tip
-
-<div class="c-project-callout c-project-callout--tip">
-
-- You can change the colour of the turtle to anything you like.
-- The `goto` sets the `x` and `y` position of the turtle on the screen.
-
-</div>
-
-### Debugging
-
-<div class="c-project-callout c-project-callout--debug">
-
-- Make sure you have quotes around the colour - `'red'`
-
-</div>
+> [!DEBUG]
+>
+> - Make sure you have quotes around the colour - `'red'`
 
 ## Now run your code
 
 Run your code and check that one turtle appears at the left side of the screen.
+
+![one red turtle at the left side of the screen](images/step_1.png)

--- a/en/step_2.md
+++ b/en/step_2.md
@@ -1,8 +1,8 @@
-<h2 class="c-project-heading--task">Add another turtle</h2>
+## Add another turtle
 
 Give your race a second speedy turtle.
 
-<h2 class="c-project-heading--explainer">Meet Bob! 🐢</h2>
+**Meet Bob! 🐢**
 
 Create a new turtle called `bob`.
 
@@ -10,46 +10,26 @@ Set Bob’s colour and shape, then move him to the next starting spot.
 
 Bob is almost the same as Ada. Just the colour and position change. The important lines that make Bob different are highlighted.
 
-
-<div class="c-project-code">
---- code ---
----
-language: python
-filename: main.py
-line_numbers: true
-line_number_start: 11
-line_highlights: 11, 12, 15
----
+```python filename="main.py" line_numbers="true" line_number_start="11" line_highlights="11,12,15"
 bob = Turtle()
 bob.color('orange')
 bob.shape('turtle')
 bob.penup()
 bob.goto(-160, 70)
 bob.pendown()
---- /code ---
-</div>
+```
 
-<div class="c-project-output">
-![two turtles, red and orange, lined up on the left](images/step_2.png)
-</div>
+> [!TIP]
+>
+> - You can pick any colour name you like for `bob`.
+> - `penup()` stops the turtle drawing a line while it moves.
 
-### Tip
-
-<div class="c-project-callout c-project-callout--tip">
-
-- You can pick any colour name you like for `bob`.
-- `penup()` stops the turtle drawing a line while it moves.
-
-</div>
-
-### Debugging
-
-<div class="c-project-callout c-project-callout--debug">
-
-- Check `bob` has a colour in quotes, like `'orange'`.
-
-</div>
+> [!DEBUG]
+>
+> - Check `bob` has a colour in quotes, like `'orange'`.
 
 ## Now run your code
 
 Run your code and check that two turtles are lined up on the left, one above the other.
+
+![two turtles, red and orange, lined up on the left](images/step_2.png)

--- a/en/step_3.md
+++ b/en/step_3.md
@@ -1,53 +1,33 @@
-<h2 class="c-project-heading--task">Add a third turtle</h2>
+## Add a third turtle
 
 Now your race needs a third turtle.
 
-<h2 class="c-project-heading--explainer">Hello, Eve! 🐢</h2>
+**Hello, Eve! 🐢**
 
 Create a turtle named `eve`.
 
 Give Eve a [colour](https://www.tcl-lang.org/man/tcl8.5/TkCmd/colors.htm) and shape, then move her to the starting line below Bob.
 
-
-<div class="c-project-code">
---- code ---
----
-language: python
-filename: main.py
-line_numbers: true
-line_number_start: 18
-line_highlights: 18, 19, 22
----
+```python filename="main.py" line_numbers="true" line_number_start="18" line_highlights="18,19,22"
 eve = Turtle()
 eve.color('yellow')
 eve.shape('turtle')
 eve.penup()
 eve.goto(-160, 40)
 eve.pendown()
---- /code ---
-</div>
+```
 
-<div class="c-project-output">
-![three turtles, red, orange, and yellow, lined up on the left](images/step_3.png)
-</div>
+> [!TIP]
+>
+> - `shape('turtle')` makes sure your turtle looks like a turtle.
+> - Try a different colour for `eve` if you want.
 
-### Tip
-
-<div class="c-project-callout c-project-callout--tip">
-
-- `shape('turtle')` makes sure your turtle looks like a turtle.
-- Try a different colour for `eve` if you want.
-
-</div>
-
-### Debugging
-
-<div class="c-project-callout c-project-callout--debug">
-
-- If you're copying and pasting, make sure you used `eve` in every line for this turtle.
-
-</div>
+> [!DEBUG]
+>
+> - If you're copying and pasting, make sure you used `eve` in every line for this turtle.
 
 ## Now run your code
 
 Run your code and check that three turtles are lined up on the left.
+
+![three turtles, red, orange, and yellow, lined up on the left](images/step_3.png)

--- a/en/step_4.md
+++ b/en/step_4.md
@@ -1,53 +1,33 @@
-<h2 class="c-project-heading--task">Add the fourth turtle</h2>
+## Add the fourth turtle
 
 Every race needs a full line-up.
 
-<h2 class="c-project-heading--explainer">Say hi to Kai! 🐢</h2>
+**Say hi to Kai! 🐢**
 
 Create a turtle called `kai`.
 
 Set the colour and shape, then move Kai to the last starting spot.
 
-
-<div class="c-project-code">
---- code ---
----
-language: python
-filename: main.py
-line_numbers: true
-line_number_start: 25
-line_highlights: 25, 26, 29
----
+```python filename="main.py" line_numbers="true" line_number_start="25" line_highlights="25,26,29"
 kai = Turtle()
 kai.color('green')
 kai.shape('turtle')
 kai.penup()
 kai.goto(-160, 10)
 kai.pendown()
---- /code ---
-</div>
+```
 
-<div class="c-project-output">
-![four turtles, red, orange, yellow, and green, lined up on the left](images/step_4.png)
-</div>
+> [!TIP]
+>
+> - Give `kai` a colour that stands out from the others.
+> - Each turtle sits on a different y-position so they do not overlap.
 
-### Tip
-
-<div class="c-project-callout c-project-callout--tip">
-
-- Give `kai` a colour that stands out from the others.
-- Each turtle sits on a different y-position so they do not overlap.
-
-</div>
-
-### Debugging
-
-<div class="c-project-callout c-project-callout--debug">
-
-- Check `goto(-160, 10)` uses a comma between x and y.
-
-</div>
+> [!DEBUG]
+>
+> - Check `goto(-160, 10)` uses a comma between x and y.
 
 ## Now run your code
 
 Run your code and check that four turtles are lined up on the left.
+
+![four turtles, red, orange, yellow, and green, lined up on the left](images/step_4.png)

--- a/en/step_5.md
+++ b/en/step_5.md
@@ -1,8 +1,8 @@
-<h2 class="c-project-heading--task">Get the track pen ready</h2>
+## Get the track pen ready
 
 Now set up the turtle that will draw the race track.
 
-<h2 class="c-project-heading--explainer">Ready, set, draw! ✏️</h2>
+**Ready, set, draw! ✏️**
 
 This will just have the basic arrow shape when it draws.
 
@@ -10,43 +10,23 @@ Lift the pen so no line is drawn.
 
 Move to the top-left corner of the track and make the turtle move fast.
 
-
-<div class="c-project-code">
---- code ---
----
-language: python
-filename: main.py
-line_numbers: true
-line_number_start: 32
-line_highlights:
----
+```python filename="main.py" line_numbers="true" line_number_start="32"
 penup()
 goto(-140, 140)
 speed(10)
---- /code ---
-</div>
+```
 
-<div class="c-project-output">
-![turtle's shown with cursor ready to draw lines](images/step_5.png)
-</div>
+> [!TIP]
+>
+> - `speed(10)` makes drawing faster so you do not have to wait.
+> - `goto(-140, 140)` moves to the top-left corner of the track.
 
-### Tip
-
-<div class="c-project-callout c-project-callout--tip">
-
-- `speed(10)` makes drawing faster so you do not have to wait.
-- `goto(-140, 140)` moves to the top-left corner of the track.
-
-</div>
-
-### Debugging
-
-<div class="c-project-callout c-project-callout--debug">
-
-- If you see a line, make sure `penup()` comes before `goto()`.
-
-</div>
+> [!DEBUG]
+>
+> - If you see a line, make sure `penup()` comes before `goto()`.
 
 ## Now run your code
 
-Run your code and check that the cursor is in the correct position
+Run your code and check that the cursor is in the correct position.
+
+![turtles shown with cursor ready to draw lines](images/step_5.png)

--- a/en/step_6.md
+++ b/en/step_6.md
@@ -1,50 +1,30 @@
-<h2 class="c-project-heading--task">Number the track</h2>
+## Number the track
 
 Add number markers along the top of the race track.
 
-<h2 class="c-project-heading--explainer">Count the steps! 🔢</h2>
+**Count the steps! 🔢**
 
 Use a loop to write the numbers `0` to `11`.
 
 After writing each number, move forward to the next spot.
 
-
-<div class="c-project-code">
---- code ---
----
-language: python
-filename: main.py
-line_numbers: true
-line_number_start: 36
-line_highlights:
----
+```python filename="main.py" line_numbers="true" line_number_start="36"
 for step in range(12):
     write(step, align = 'center')
     forward(20)
---- /code ---
-</div>
+```
 
-<div class="c-project-output">
-![a small arrow at the top left with the turtles lined up on the left](images/step_6.png)
-</div>
+> [!TIP]
+>
+> - `range(12)` gives you the numbers `0` to `11`.
+> - `write(step)` prints the number on the screen.
 
-### Tip
-
-<div class="c-project-callout c-project-callout--tip">
-
-- `range(12)` gives you the numbers `0` to `11`.
-- `write(step)` prints the number on the screen.
-
-</div>
-
-### Debugging
-
-<div class="c-project-callout c-project-callout--debug">
-
-- If all the numbers sit on top of each other, check `forward(20)` is inside the loop.
-
-</div>
+> [!DEBUG]
+>
+> - If all the numbers sit on top of each other, check `forward(20)` is inside the loop.
 
 ## Now run your code
 
 Run your code and check that the number line stays at the top and the turtles are still lined up on the left.
+
+![a small arrow at the top left with the turtles lined up on the left](images/step_6.png)

--- a/en/step_7.md
+++ b/en/step_7.md
@@ -1,23 +1,14 @@
-<h2 class="c-project-heading--task">Draw the race markers</h2>
+## Draw the race markers
 
 Add the race markers under each number.
 
-<h2 class="c-project-heading--explainer">Make the track! 🏁</h2>
+**Make the track! 🏁**
 
 Inside the loop, make the arrow turtle turn and draw a line down for each marker.
 
 Then move it back up, face forward again, and write the next number.
 
-
-<div class="c-project-code">
---- code ---
----
-language: python
-filename: main.py
-line_numbers: true
-line_number_start: 36
-line_highlights: 38-44
----
+```python filename="main.py" line_numbers="true" line_number_start="36" line_highlights="38-44"
 for step in range(12):
     right(90)
     forward(10)
@@ -28,30 +19,19 @@ for step in range(12):
     left(90)
     write(step, align = 'center')
     forward(20)
---- /code ---
-</div>
+```
 
-<div class="c-project-output">
-![numbers 0 to 11 with vertical lane lines and turtles on the left](images/step_7.png)
-</div>
+> [!TIP]
+>
+> - `pendown()` starts drawing the lane markers.
+> - `penup()` lifts the pen so you can move without drawing.
 
-### Tip
-
-<div class="c-project-callout c-project-callout--tip">
-
-- `pendown()` starts drawing the lane markers.
-- `penup()` lifts the pen so you can move without drawing.
-
-</div>
-
-### Debugging
-
-<div class="c-project-callout c-project-callout--debug">
-
-- If your lines go the wrong way, check the `right(90)` and `left(90)` turns.
-
-</div>
+> [!DEBUG]
+>
+> - If your lines go the wrong way, check the `right(90)` and `left(90)` turns.
 
 ## Now run your code
 
 Run your code and check that vertical lane lines are drawn under the numbers.
+
+![numbers 0 to 11 with vertical lane lines and turtles on the left](images/step_7.png)

--- a/en/step_8.md
+++ b/en/step_8.md
@@ -1,52 +1,32 @@
-<h2 class="c-project-heading--task">Start the race</h2>
+## Start the race
 
 Make the turtles move forward a random amount each turn.
 
-<h2 class="c-project-heading--explainer">Let them race! 🐢🐢🐢🐢</h2>
+**Let them race! 🐢🐢🐢🐢**
 
 Use a loop to take 100 turns.
 
 On each turn, move every turtle forward by a random number of steps.
 
-
-<div class="c-project-code">
---- code ---
----
-language: python
-filename: main.py
-line_numbers: true
-line_number_start: 47
-line_highlights:
----
+```python filename="main.py" line_numbers="true" line_number_start="47"
 for turn in range(100):
     ada.forward(randint(1,5))
     bob.forward(randint(1,5))
     eve.forward(randint(1,5))
     kai.forward(randint(1,5))
---- /code ---
-</div>
+```
 
-<div class="c-project-output">
-![four turtles racing across coloured lane lines](images/step_8.png)
-</div>
+> [!TIP]
+>
+> - `randint(1,5)` picks a random number from 1 to 5.
+> - Bigger numbers make a turtle move further each turn.
 
-### Tip
-
-<div class="c-project-callout c-project-callout--tip">
-
-- `randint(1,5)` picks a random number from 1 to 5.
-- Bigger numbers make a turtle move further each turn.
-
-</div>
-
-### Debugging
-
-<div class="c-project-callout c-project-callout--debug">
-
-- If you see an error, check you wrote `randint(1,5)` with brackets and a comma.
-
-</div>
+> [!DEBUG]
+>
+> - If you see an error, check you wrote `randint(1,5)` with brackets and a comma.
 
 ## Now run your code
 
 Run your code and check that the turtles start moving across the track.
+
+![four turtles racing across coloured lane lines](images/step_8.png)


### PR DESCRIPTION
Converts all step files to Raspberry Flavoured Markdown (RPF): task headings → `##`, code blocks → fenced blocks with inline attributes, tips → `> [!TIP]`, debug → `> [!DEBUG]`, output wrappers dropped to bare images.

Editorial decision agreed with the team:
- The playful per-turtle subtitles ('Say hello to Ada! 🐢', 'Meet Bob! 🐢', … 'Let them race! 🐢🐢🐢🐢') are kept as **bold lead-in lines** in each step (rather than dropped), preserving the character without a second heading.
- SPAG: step_5 missing full stop and 'turtle's' → 'turtles' in alt text.

No code errors found.

`listed: true` preserved (stays published).